### PR TITLE
Build on stable through a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,12 @@ authors = ["Curtis Gagliardi <curtis@curtis.io>"]
 rustbox = "*"
 rand = "*"
 unicode-segmentation = "*"
-clippy="*"
+
+[dependencies.clippy]
+clippy = "*"
+optional = true
+
+[features]
+default = []
+
+lints = ["clippy"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-#![feature(plugin)]
-#![plugin(clippy)]
+#![cfg_attr(feature = "lints", feature(plugin))]
+#![cfg_attr(feature = "lints", plugin(clippy))]
 
 extern crate rustbox;
 extern crate rand;


### PR DESCRIPTION
This relies on https://github.com/cgag/hostblock/pull/3 so I've included it as well.

Right now, the codebase requires Rust nightly. But this is only due to
using clippy. As such, by creating a Cargo feature, we can build it only
when we want lints:

```
# on stable
$ cargo build

# on nightly
$ cargo build --features lints
```
