### PR TITLE
Implementation of issue 8: block all/unblock all from command line -- second attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 /target/
 
 core
+
+#vim
+*.swp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "hostblock"
 version = "0.1.1"
 dependencies = [
  "clippy 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustbox 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -38,6 +39,11 @@ dependencies = [
  "libc 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "getopts"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ clippy = "*"
 optional = true
 
 [features]
-default = []
+default = ["commandline_unblock"]
+
+# enables the -u option
+# to disable remove from default
+commandline_unblock = []
 
 lints = ["clippy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Curtis Gagliardi <curtis@curtis.io>"]
 rustbox = "*"
 rand = "*"
 unicode-segmentation = "*"
+getopts = "0.2"
 
 [dependencies.clippy]
 clippy = "*"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ Controls
   - q     - Quit current mode, quits app if in normal mode.
   - h     - View help.
 
+Command line options:
+ - `b` block all
+ - `u` unblock all (requires typing the passphrase)
+ - `h` help message
+
 ### Installation:
 
 #### Linux x86_64 binary

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Controls
 Command line options:
  - `-b` block all
  - `-u` unblock all (requires typing the passphrase)
- - `-h` help message
+ - `-h` help message (showing these options)
 
 ### Installation:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Controls
   - h     - View help.
 
 Command line options:
- - `b` block all
- - `u` unblock all (requires typing the passphrase)
- - `h` help message
+ - `-b` block all
+ - `-u` unblock all (requires typing the passphrase)
+ - `-h` help message
 
 ### Installation:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,17 +157,6 @@ fn read_args() -> (bool, State){
         }
         Err(f) => { panic!(f.to_string()) }
     };
-    match args.clone().pop().as_ref().map(String::as_ref) {
-        Some("-h") => {
-            print!("HHHH")
-        }
-        Some(x) =>{
-            print!("{}",x)
-        }
-        _ => {
-            print!("Nothing")
-        }
-    }
     if matches.opt_present("h") {
         print_usage(&program, opts);
         return (false, state);

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,7 @@ fn read_args() -> (bool, State){
         return (false, block_all(state));
     }
     if matches.opt_present("u"){
+        // doing it like this doesn't change the runtime behavior to much
         if cfg!(feature = "commandline_unblock"){
             // fall into the menu to allow the passphrase
             return (true, unblock_all(state));

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,8 +148,7 @@ fn read_args(state:&mut State) -> bool{
     let program = args[0].clone();
 
     let mut opts = Options::new();
-    opts.optflag("u", "unblock", "unblock all hosts (requires not on
-        autopilot validation)");
+    opts.optflag("u", "unblock", "unblock all hosts (requires passphrase)");
     opts.optflag("b", "block", "block all hosts");
     opts.optflag("h", "help", "print this help menu");
     let matches = match opts.parse(&args[1..]) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,24 +158,24 @@ fn read_args() -> (bool, State){
         Err(f) => { panic!(f.to_string()) }
     };
     // TODO: patern matching??
-    match matches.opt_str(){
-        "h" =>{
-            print_usage(&program, opts);
-            (false, state);
-        }
-        "b" =>{
-            print!("hosts blocked");
-            (false, block_all(state));
-        }
-        "u" =>{
+    if matches.opt_present("h") {
+        print_usage(&program, opts);
+        return (false, state);
+    }
+    if matches.opt_present("b") {
+        print!("hosts blocked");
+        return (false, block_all(state));
+    }
+    if matches.opt_present("u"){
+        if cfg!(feature = "commandline_unblock"){
             // fall into the menu to allow the passphrase
-            (true, unblock_all(state));
+            return (true, unblock_all(state));
         }
-        _ => {
-            (true, state);
-        }
-    };
+        print!("unblock via commandline disabled in this build");
+        return (false,state);
+    }
 
+    return (true, state);
 }
 
 fn handle_key(key: rustbox::Key, state: &State) -> (bool, State) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,17 @@ fn read_args() -> (bool, State){
         }
         Err(f) => { panic!(f.to_string()) }
     };
+    match args.clone().pop().as_ref().map(String::as_ref) {
+        Some("-h") => {
+            print!("HHHH")
+        }
+        Some(x) =>{
+            print!("{}",x)
+        }
+        _ => {
+            print!("Nothing")
+        }
+    }
     if matches.opt_present("h") {
         print_usage(&program, opts);
         return (false, state);

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn main() {
 // false, nevermind show the GUI
 fn read_args(state:&mut State) -> bool{
     fn print_usage(program: &str, opts: Options) {
-        let brief = format!("Usage: {} FILE [options]", program);
+        let brief = format!("Usage: {} [options]", program);
         print!("{}", opts.usage(&brief));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,6 @@ fn read_args() -> (bool, State){
         }
         Err(f) => { panic!(f.to_string()) }
     };
-    // TODO: patern matching??
     if matches.opt_present("h") {
         print_usage(&program, opts);
         return (false, state);

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,7 @@ fn read_args(state:&mut State) -> bool{
         Ok(m) => { m }
         Err(f) => { panic!(f.to_string()) }
     };
+    // TODO: patern matching??
     if matches.opt_present("h") {
         print_usage(&program, opts);
         return false;
@@ -164,6 +165,16 @@ fn read_args(state:&mut State) -> bool{
         state.domains = block_all(state).domains;
         print!("hosts blocked");
         return false;
+    }
+    if matches.opt_present("u"){
+        // TODO: not in such a stupid way (I thought the & was just a
+        // reference, aperantly overwriting it is impossible.)
+        let result = unblock_all(state);
+        state.domains = result.domains;
+        state.status = result.status;
+        state.mode = Mode::Password;
+        // fall into the menu to allow the annoying sentence typing
+        return true;
     }
 
     return true;
@@ -374,12 +385,21 @@ fn password_backspace(state: &State) -> State {
     new_state.pass_input.pop();
     new_state
 }
-fn block_all(state:&mut State) -> State{
+fn block_all(state:&State) -> State{
     let mut new_state = state.clone();
     new_state.domains = new_state.domains.into_iter().map(|domain| Domain{
         url:domain.url.clone(),
         status:DomainStatus::Blocked
     }).collect();
+    new_state
+}
+fn unblock_all(state:&State) -> State{
+    let mut new_state = state.clone();
+    new_state.domains = new_state.domains.into_iter().map(|domain| Domain{
+        url:domain.url.clone(),
+        status:DomainStatus::Unblocked
+    }).collect();
+    new_state.status = Status::Dirty;
     new_state
 }
 


### PR DESCRIPTION
Hi

So I made some modifications. I didn't do the pattern matching because I don't really know how to do that right, there is one commit where I have some implementation but I deleted it because its more picky then the current implementation, for example if a user would do "-hu" nothing would be matched with pattern matching (at least how I implemented it), but in the current implementation the "h" will be followed.

Compared to last request I increased the pass phrase size for -u and added a compile option to allow disabling of that option. 

Read args now also creates the state, which makes it the owner so it can be overwritten. In practice however the created state gets consumed by either the block or unblock functions if those options are present (and they in turn create a new state).
Read args still returns the boolean, but also the state.

I hope you are happy with these changes, if not I would again like to hear your opinion.

Cheers
